### PR TITLE
Fix build validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,12 +195,12 @@ jobs:
         
         echo "✅ Extension package created successfully"
         
-    - name: Upload extension package
-      uses: actions/upload-artifact@v3
-      with:
-        name: extension-package
-        path: dist/webrtc-stats-exporter-pro-*.zip
-        retention-days: 30
+      - name: Upload extension package
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-package
+          path: dist/webrtc-stats-exporter-pro-*.zip
+          retention-days: 30
 
   performance-test:
     name: Performance Test


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in CI workflow

## Testing
- `npm run validate`

------
https://chatgpt.com/codex/tasks/task_e_684949f960fc8323a2b392a766b3c085