### PR TITLE
Implement two-stage WebRTC override injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,11 @@ jobs:
       run: |
         required_files=(
           "background.js"
-          "content-script.js"
+          "content-script-start.js"
+          "content-script-end.js"
           "override.js"
+          "override-stage1.js"
+          "override-stage2.js"
           "popup.html"
           "popup.js"
           "options.html"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Access the extension options by:
 - **Storage Circuit Breaker** (`shared/storage-circuit-breaker.js`): Handles storage operation reliability
 - **Pushgateway Client** (`background/pushgateway-client.js`): Manages metric export with retry logic
 - **Connection Tracker** (`background/connection-tracker.js`): Monitors WebRTC connection lifecycle
-- **Content Script** (`content-script.js`): Injected into target pages to detect WebRTC usage
+- **Content Scripts** (`content-script-start.js`, `content-script-end.js`): Injected into pages at start and idle phases to detect WebRTC usage
 - **Override Script** (`override.js`): Hooks into RTCPeerConnection to capture statistics
 - **Shared Modules** (`shared/`): Centralized configuration, domain management, and storage
 
@@ -158,7 +158,8 @@ npm run test:ci         # CI mode with full reporting
 │   ├── storage.js          # Storage abstraction with circuit breaker
 │   ├── storage-circuit-breaker.js  # Storage fault tolerance
 │   └── lifecycle-manager.js        # Resource lifecycle management
-├── content-script.js       # Content script for target pages
+├── content-script-start.js # Injection script (runs at document_start)
+├── content-script-end.js   # Main content script for stats and messaging
 ├── override.js            # WebRTC hook injection script
 ├── popup.html/js          # Extension popup UI
 ├── options.html/js        # Options page UI

--- a/content-script-end.js
+++ b/content-script-end.js
@@ -50,7 +50,7 @@ if (window.location.protocol.startsWith('http')) {
     }
   }
 
-  setTimeout(() => injectScript(chrome.runtime.getURL('override.js')))
+  setTimeout(() => injectScript(chrome.runtime.getURL('override-stage2.js')))
 
   // Handle options.
   const options = {
@@ -63,6 +63,12 @@ if (window.location.protocol.startsWith('http')) {
   const sendOptions = () => {
     window.postMessage({
       event: 'webrtc-internal-exporter:options',
+      options
+    })
+
+    // For newer override scripts using the `type` field
+    window.postMessage({
+      type: 'webrtc-exporter-options',
       options
     })
   }
@@ -166,11 +172,11 @@ if (window.location.protocol.startsWith('http')) {
 
     // Handle messages from override script (options and legacy stats events)
     window.addEventListener('message', (message) => {
-      const { event, url, id, state, values } = message.data
-      if (event === 'webrtc-internal-exporter:ready') {
+      const { event, type, url, id, state, values } = message.data
+      if (event === 'webrtc-internal-exporter:ready' || type === 'webrtc-exporter-ready') {
         console.log('[webrtc-internal-exporter:content-script] Override script ready, sending options')
         sendOptions()
-      } else if (event === 'webrtc-internal-exporter:peer-connection-stats') {
+      } else if (event === 'webrtc-internal-exporter:peer-connection-stats' || type === 'webrtc-exporter-peer-connection-stats') {
         console.log('[webrtc-internal-exporter:content-script] Received peer-connection-stats', { url, id, state, valuesCount: values?.length })
         log('peer-connection-stats', { url, id, state, values })
         try {

--- a/content-script-start.js
+++ b/content-script-start.js
@@ -1,0 +1,6 @@
+/* global chrome */
+
+const s = document.createElement('script')
+s.src = chrome.runtime.getURL('override-stage1.js')
+(document.head || document.documentElement).appendChild(s)
+s.onload = () => s.remove()

--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,9 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "override.js", 
+        "override.js",
+        "override-stage1.js",
+        "override-stage2.js",
         "shared/config.js", 
         "shared/domains.js", 
         "shared/storage.js",
@@ -81,8 +83,29 @@
         "*://*.mypurecloud.jp/*",
         "*://*.pure.cloud/*"
       ],
-      "js": ["content-script.js"],
-      "run_at": "document_start"
+      "js": ["content-script-start.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": [
+        "*://*.teams.microsoft.com/*",
+        "*://teams.microsoft.com/*",
+        "*://meet.google.com/*",
+        "*://*.meet.google.com/*",
+        "*://*.awsapps.com/*",
+        "*://*.my.connect.aws/*",
+        "*://*.mypurecloud.com/*",
+        "*://*.genesys.com/*",
+        "*://*.mypurecloud.com.au/*",
+        "*://*.mypurecloud.ie/*",
+        "*://*.mypurecloud.de/*",
+        "*://*.mypurecloud.jp/*",
+        "*://*.pure.cloud/*"
+      ],
+      "js": ["content-script-end.js"],
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ]
 }

--- a/override-stage1.js
+++ b/override-stage1.js
@@ -1,0 +1,17 @@
+console.log('[webrtc-exporter:override-stage1] Running...')
+
+// Preserve original peer connection constructor
+window.RTCPeerConnection_ORIGINAL = window.RTCPeerConnection
+
+Object.defineProperty(window, 'RTCPeerConnection', {
+  configurable: true,
+  enumerable: true,
+  get() {
+    console.log('[webrtc-exporter:override-stage1] GET RTCPeerConnection')
+    return window.RTCPeerConnection_PROXY || window.RTCPeerConnection_ORIGINAL
+  },
+  set(newValue) {
+    console.log('[webrtc-exporter:override-stage1] SET RTCPeerConnection to shim')
+    window.RTCPeerConnection_SHIM = newValue
+  }
+})

--- a/override-stage2.js
+++ b/override-stage2.js
@@ -1,0 +1,112 @@
+(function () {
+  console.log('[webrtc-exporter:override-stage2] Running...')
+
+  const FinalPeerConnection = window.RTCPeerConnection_SHIM || window.RTCPeerConnection_ORIGINAL
+  if (!FinalPeerConnection) {
+    console.error('[webrtc-exporter:override-stage2] No PeerConnection to wrap!')
+    return
+  }
+
+  const webrtcInternalsExporter = new WebrtcInternalsExporter()
+
+  class RTCPeerConnectionProxy extends FinalPeerConnection {
+    constructor(...args) {
+      console.log('!!!!!! [webrtc-exporter] new RTCPeerConnection() CONSTRUCTOR CALLED !!!!!!', args)
+      super(...args)
+      webrtcInternalsExporter.add(this)
+    }
+  }
+
+  for (const staticMethod in FinalPeerConnection) {
+    if (Object.prototype.hasOwnProperty.call(FinalPeerConnection, staticMethod)) {
+      RTCPeerConnectionProxy[staticMethod] = FinalPeerConnection[staticMethod]
+    }
+  }
+
+  window.RTCPeerConnection = RTCPeerConnectionProxy
+  window.RTCPeerConnection_PROXY = RTCPeerConnectionProxy
+
+  console.log('[webrtc-exporter:override-stage2] Final hook is in place.')
+
+  // --- WebrtcInternalsExporter class ---
+  class WebrtcInternalsExporter {
+    peerConnections = new Map()
+
+    url = ''
+    enabled = false
+    updateInterval = 2000
+    enabledStats = []
+
+    constructor () {
+      window.addEventListener('message', async (message) => {
+        if (message.data && message.data.type === 'webrtc-exporter-options') {
+          console.log('[webrtc-exporter:override-stage2] Options received:', message.data.options)
+          Object.assign(this, message.data.options)
+        }
+      })
+
+      console.log('[webrtc-exporter:override-stage2] Exporter initialized, posting ready event')
+      window.postMessage({ type: 'webrtc-exporter-ready' })
+    }
+
+    static log (...args) {
+      console.log('[webrtc-exporter:override-stage2]', ...args)
+    }
+
+    static randomId () {
+      if ('randomUUID' in window.crypto) {
+        return window.crypto.randomUUID()
+      } else {
+        return (Date.now() + Math.random()).toString(36)
+      }
+    }
+
+    add (pc) {
+      const id = WebrtcInternalsExporter.randomId()
+      WebrtcInternalsExporter.log(`Adding RTCPeerConnection with ID: ${id}`)
+      this.peerConnections.set(id, pc)
+
+      pc.addEventListener('connectionstatechange', () => {
+        WebrtcInternalsExporter.log(`Connection state for ${id} changed to: ${pc.connectionState}`)
+        if (pc.connectionState === 'closed' || pc.connectionState === 'failed') {
+          this.collectStats(id)
+          this.peerConnections.delete(id)
+        }
+      })
+
+      this.collectStats(id)
+    }
+
+    async collectStats (id) {
+      const pc = this.peerConnections.get(id)
+      if (!pc) return
+
+      if (this.url && this.enabled) {
+        try {
+          const stats = await pc.getStats()
+          const allStats = [...stats.values()]
+          const values = allStats.filter(v => ['peer-connection', ...this.enabledStats].includes(v.type))
+
+          if (values.length > 0) {
+            const payload = {
+              url: window.location.href,
+              id,
+              state: pc.connectionState,
+              values
+            }
+            const event = new CustomEvent('webrtcStatsToRelay', { detail: payload })
+            window.dispatchEvent(event)
+          }
+        } catch (error) {
+          WebrtcInternalsExporter.log(`Error in collectStats for ${id}: ${error.message}`)
+          this.peerConnections.delete(id)
+          return
+        }
+      }
+
+      if (this.peerConnections.has(id)) {
+        setTimeout(() => this.collectStats(id), this.updateInterval)
+      }
+    }
+  }
+})()

--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -18,12 +18,15 @@ const PACKAGE_JSON = require(path.join(ROOT_DIR, 'package.json'))
 const INCLUDE_FILES = [
   'manifest.json',
   'background.js',
-  'content-script.js',
+  'content-script-start.js',
+  'content-script-end.js',
   'options.html',
   'options.js',
   'popup.html',
   'popup.js',
   'override.js',
+  'override-stage1.js',
+  'override-stage2.js',
   'LICENSE',
   'README.md'
 ]


### PR DESCRIPTION
## Summary
- split the content script into `content-script-start.js` and `content-script-end.js`
- inject new `override-stage1.js` at document_start and `override-stage2.js` at document_idle
- hook `RTCPeerConnection` shim after adapter loads
- keep sending stats and options through updated content script
- update manifest, packaging script and CI workflow to include new files
- document the new scripts in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b6d310a88323a971a50ea2a9e852