### PR TITLE
Implement postMessage bridge

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,19 +1,52 @@
-console.log('[webrtc-exporter:content-script] Injecting unified override script...')
-const s = document.createElement('script')
-s.src = chrome.runtime.getURL('override.js');
-(document.head || document.documentElement).appendChild(s)
-s.onload = () => s.remove()
+(function() {
+    'use strict';
+    console.log('[webrtc-exporter:content-script] Running at document_start.');
 
-const port = chrome.runtime.connect({ name: 'webrtc-stats-port' })
-port.onDisconnect.addListener(() => { /* ... error handling ... */ })
+    // --- Part 1: Injection ---
+    const script = document.createElement('script');
+    script.src = chrome.runtime.getURL('override.js');
+    (document.head || document.documentElement).appendChild(script);
+    script.onload = () => script.remove();
+    console.log('[webrtc-exporter:content-script] Injected override script.');
 
-window.addEventListener('webrtcStatsToRelay', (event) => {
-  try {
-    port.postMessage({
-      type: 'webrtc_stats_payload',
-      data: event.detail
-    })
-  } catch (e) {
-    console.error('[content-script.js] Port postMessage failed:', e)
-  }
-}, false)
+    // --- Part 2: Communication Bridge ---
+    let port = null;
+
+    function connect() {
+        if (port) return; // Already connected
+        try {
+            port = chrome.runtime.connect({ name: 'webrtc-stats-port' });
+            port.onDisconnect.addListener(() => {
+                console.warn('[webrtc-exporter:content-script] Port disconnected.');
+                port = null;
+            });
+            console.log('[webrtc-exporter:content-script] Port connected to background.');
+        } catch (error) {
+            console.error('[webrtc-exporter:content-script] Could not connect to background script:', error);
+            port = null;
+        }
+    }
+
+    window.addEventListener('message', (event) => {
+        if (event.source !== window || event.data.source !== 'webrtc-exporter-override') {
+            return;
+        }
+
+        console.log('[webrtc-exporter:content-script] Received message from page:', event.data);
+        if (!port) {
+            connect();
+        }
+        if (port) {
+            try {
+                port.postMessage(event.data);
+            } catch (error) {
+                console.error('[webrtc-exporter:content-script] Failed to relay message to background. Port may be closed.', error);
+                port = null;
+            }
+        } else {
+            console.error('[webrtc-exporter:content-script] Port not available to relay message.');
+        }
+    });
+
+    connect();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -37,23 +37,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "override.js",
-        "shared/config.js", 
-        "shared/domains.js", 
-        "shared/storage.js",
-        "shared/storage-circuit-breaker.js",
-        "shared/lifecycle-manager.js",
-        "background/stats-formatter.js", 
-        "background/pushgateway-client.js", 
-        "background/network-circuit-breaker.js",
-        "background/options-manager.js", 
-        "background/connection-tracker.js", 
-        "background/lifecycle-manager.js", 
-        "background/tab-monitor.js", 
-        "background/message-handler.js",
-        "assets/pako.min.js"
-      ],
+      "resources": ["override.js"],
       "matches": ["<all_urls>"]
     }
   ],

--- a/tests/unit/import-paths.test.js
+++ b/tests/unit/import-paths.test.js
@@ -116,18 +116,7 @@ describe('Import Path Validation', () => {
       
       const webAccessibleResources = manifest.web_accessible_resources?.[0]?.resources || []
       
-      const requiredResources = [
-        'shared/config.js',
-        'shared/domains.js', 
-        'shared/storage.js',
-        'background/stats-formatter.js',
-        'background/pushgateway-client.js',
-        'background/options-manager.js',
-        'background/connection-tracker.js',
-        'background/lifecycle-manager.js',
-        'background/tab-monitor.js',
-        'background/message-handler.js'
-      ]
+      const requiredResources = ['override.js']
       
       const missingResources = requiredResources.filter(resource => 
         !webAccessibleResources.includes(resource)


### PR DESCRIPTION
## Summary
- simplify content script to inject override and relay messages via postMessage
- tighten manifest web_accessible_resources to only expose override.js
- broadcast peer connection events from override.js via postMessage
- update import-path test for new manifest rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c7a077cc83239f8bda3a9bf7c811