### PR TITLE
Fix packaging script output filename

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -120,8 +120,8 @@ function updateManifestVersion () {
 }
 
 function createZipPackage () {
-  const version = PACKAGE_JSON.version
-  const zipName = `webrtc-stats-exporter-v${version}.zip`
+  // Use a consistent name expected by CI and release workflows
+  const zipName = 'webrtc-stats-exporter-pro.zip'
   const zipPath = path.join(ROOT_DIR, zipName)
 
   log(`Creating zip package: ${zipName}`)


### PR DESCRIPTION
## Summary
- make packaging script output `webrtc-stats-exporter-pro.zip` for CI workflows

## Testing
- `npm run lint`
- `npm test`
- `npm run package`


------
https://chatgpt.com/codex/tasks/task_e_6855cc3388188323986988f70e2bb32f