### PR TITLE
Update release workflow token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
       with:
         tag_name: ${{ steps.tag.outputs.tag }}
         release_name: WebRTC Stats Exporter Pro ${{ steps.tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ The project includes GitHub Actions workflows for:
 - **Build Validation**: Extension packaging and artifact creation
 - **Coverage Reporting**: Automated coverage tracking and reporting
 
+To publish releases from GitHub Actions, add a repository secret named
+`GH_RELEASE_TOKEN` containing a personal access token with `repo`
+permissions. The release workflow uses this token when invoking
+`actions/create-release`.
+
 ## 🎯 Enterprise Ready
 
 ### **Reliability Features**


### PR DESCRIPTION
## Summary
- clarify that a GH_RELEASE_TOKEN secret is required for release workflow
- use `GH_RELEASE_TOKEN` when creating GitHub releases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d3a4517c8323a0ba55e96c9ca760