### PR TITLE
Fix docs to reflect Proxy-based RTCPeerConnection interception

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Brief description of changes made.
 If you've modified any of these files, please verify:
 
 ### RTCPeerConnection Interception (`override.js`)
-- [ ] `Object.defineProperty(window, 'RTCPeerConnection')` still present
+- [ ] `new Proxy(window.RTCPeerConnection)` wrapping present
 - [ ] Proxy constructor calls `webrtcInternalsExporter.add(pc)`
 - [ ] Stats collection still works via `collectStats()`
 - [ ] Connection state change handlers intact

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
           echo "⚠️  Critical files modified - extra validation required"
           
           # Check RTCPeerConnection interception hasn't been broken
-          if ! grep -q "Object.defineProperty.*RTCPeerConnection" override.js; then
+          if ! grep -q "new Proxy(window.RTCPeerConnection" override.js; then
             echo "❌ RTCPeerConnection interception may be broken"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- update documentation to explain new Proxy wrapping
- update Mermaid docs to remove old Object.defineProperty references
- update PR template and validation workflow to check for Proxy instead of defineProperty

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint:check` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855db402cc483238498381cf29fe2d9